### PR TITLE
feat: add w:tab translator

### DIFF
--- a/packages/super-editor/src/core/super-converter/v3/handlers/index.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/index.js
@@ -1,4 +1,5 @@
 import { translator as w_br_translator } from './w/br/br-translator.js';
+import { translator as w_tab_translator } from './w/tab/tab-translator.js';
 
 /**
  * @typedef {Object} RegisteredHandlers
@@ -6,4 +7,5 @@ import { translator as w_br_translator } from './w/br/br-translator.js';
 
 export const registeredHandlers = Object.freeze({
   'w:br': w_br_translator,
+  'w:tab': w_tab_translator,
 });

--- a/packages/super-editor/src/core/super-converter/v3/handlers/index.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/index.js
@@ -1,5 +1,6 @@
 import { translator as w_br_translator } from './w/br/br-translator.js';
 import { translator as w_tab_translator } from './w/tab/tab-translator.js';
+import { translator as w_hyperlink_translator } from './w/hyperlink/hyperlink-translator.js';
 
 /**
  * @typedef {Object} RegisteredHandlers
@@ -8,4 +9,5 @@ import { translator as w_tab_translator } from './w/tab/tab-translator.js';
 export const registeredHandlers = Object.freeze({
   'w:br': w_br_translator,
   'w:tab': w_tab_translator,
+  'w:hyperlink': w_hyperlink_translator,
 });

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/hyperlink/hyperlink-translator.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/hyperlink/hyperlink-translator.js
@@ -1,0 +1,73 @@
+// @ts-check
+import { NodeTranslator } from '../../../node-translator/index.js';
+
+/** @type {import('../../../node-translator/index.js').XmlNodeName} */
+const XML_NODE_NAME = 'w:hyperlink';
+
+/** @type {import('../../../node-translator/index.js').SuperDocNodeOrKeyName} */
+const SD_NODE_NAME = 'hyperlink';
+
+/**
+ * The attributes that can be mapped between OOXML and SuperDoc.
+ * @type {import('../../../node-translator/index.js').AttributesHandlerList[]}
+ */
+const attributes = [
+  { xmlName: 'r:id', sdName: 'rId', encode: (attrs) => attrs['r:id'], decode: (attrs) => attrs.rId },
+  { xmlName: 'w:anchor', sdName: 'anchor', encode: (attrs) => attrs['w:anchor'], decode: (attrs) => attrs.anchor },
+  { xmlName: 'w:history', sdName: 'history', encode: (attrs) => attrs['w:history'], decode: (attrs) => attrs.history },
+];
+
+/**
+ * Encode a <w:hyperlink> element into a SuperDoc hyperlink node.
+ * @param {import('../../../node-translator/index.js').SCEncoderConfig} params
+ * @param {import('../../../node-translator/index.js').EncodedAttributes} [encodedAttrs]
+ * @returns {import('../../../node-translator/index.js').SCEncoderResult}
+ */
+const encode = (params, encodedAttrs) => {
+  const { nodes, nodeListHandler } = params;
+  const node = nodes[0];
+  const children = node?.elements || [];
+  const content = nodeListHandler ? nodeListHandler.handler({ ...params, nodes: children }) : [];
+
+  const translated = { type: 'hyperlink', content };
+  if (encodedAttrs && Object.keys(encodedAttrs).length) {
+    translated.attrs = { ...encodedAttrs };
+  }
+  return translated;
+};
+
+/**
+ * Decode a SuperDoc hyperlink node back into OOXML <w:hyperlink>.
+ * @param {import('../../../node-translator/index.js').SCDecoderConfig} params
+ * @param {import('../../../node-translator/index.js').DecodedAttributes} [decodedAttrs]
+ * @returns {import('../../../node-translator/index.js').SCDecoderResult}
+ */
+const decode = (params, decodedAttrs) => {
+  const { node, children } = params;
+  if (!node) return;
+
+  const wHyperlink = { name: 'w:hyperlink' };
+  if (decodedAttrs && Object.keys(decodedAttrs).length) {
+    wHyperlink.attributes = { ...decodedAttrs };
+  }
+  if (children && Array.isArray(children) && children.length) {
+    wHyperlink.elements = children;
+  }
+  return wHyperlink;
+};
+
+/** @type {import('../../../node-translator/index.js').NodeTranslatorConfig} */
+export const config = {
+  xmlName: XML_NODE_NAME,
+  sdNodeOrKeyName: SD_NODE_NAME,
+  type: NodeTranslator.translatorTypes.NODE,
+  encode,
+  decode,
+  attributes,
+};
+
+/**
+ * The NodeTranslator instance for the w:hyperlink element.
+ * @type {import('../../../node-translator/index.js').NodeTranslator}
+ */
+export const translator = NodeTranslator.from(config);

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/hyperlink/hyperlink-translator.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/hyperlink/hyperlink-translator.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { config } from './index.js';
+
+describe('w:hyperlink translator config', () => {
+  describe('encode', () => {
+    it('encodes children with nodeListHandler and returns a SuperDoc hyperlink node', () => {
+      const child = { name: 'w:r' };
+      const processed = [{ type: 'text', text: 'hello' }];
+      const nodeListHandler = { handler: vi.fn().mockReturnValue(processed) };
+      const params = { nodes: [{ name: 'w:hyperlink', elements: [child] }], nodeListHandler };
+      const res = config.encode(params, undefined);
+      expect(nodeListHandler.handler).toHaveBeenCalledTimes(1);
+      expect(nodeListHandler.handler).toHaveBeenCalledWith({ ...params, nodes: [child] });
+      expect(res).toEqual({ type: 'hyperlink', content: processed });
+    });
+
+    it('includes all provided encoded attributes on the SuperDoc node', () => {
+      const encodedAttrs = { rId: 'rId5', anchor: 'a1', history: '1' };
+      const nodeListHandler = { handler: vi.fn().mockReturnValue([]) };
+      const params = { nodes: [{ name: 'w:hyperlink', elements: [] }], nodeListHandler };
+      const res = config.encode(params, encodedAttrs);
+      expect(res.type).toBe('hyperlink');
+      expect(res.attrs).toEqual(encodedAttrs);
+      expect(res.content).toEqual([]);
+    });
+  });
+
+  describe('decode', () => {
+    it('decodes to <w:hyperlink> with children and attributes', () => {
+      const children = [{ name: 'w:r' }];
+      const decodedAttrs = { 'r:id': 'rId5', 'w:anchor': 'a1' };
+      const res = config.decode({ node: { type: 'hyperlink', content: children }, children }, decodedAttrs);
+      expect(res).toEqual({ name: 'w:hyperlink', attributes: decodedAttrs, elements: children });
+    });
+
+    it('returns undefined when params.node is missing', () => {
+      const res = config.decode({ children: [] }, { 'r:id': 'rId5' });
+      expect(res).toBeUndefined();
+    });
+  });
+
+  describe('attributes mapping metadata', () => {
+    it('exposes expected attribute handlers', () => {
+      const attrMap = config.attributes;
+      const names = attrMap.map((a) => [a.xmlName, a.sdName]);
+      expect(names).toContainEqual(['r:id', 'rId']);
+      expect(names).toContainEqual(['w:anchor', 'anchor']);
+      expect(names).toContainEqual(['w:history', 'history']);
+    });
+  });
+});

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/hyperlink/index.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/hyperlink/index.js
@@ -1,0 +1,1 @@
+export * from './hyperlink-translator.js';

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/index.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/index.js
@@ -1,0 +1,1 @@
+export * from './tab-translator.js';

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/tab-translator.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/tab-translator.js
@@ -1,0 +1,59 @@
+// @ts-check
+import { NodeTranslator } from '../../../node-translator/index.js';
+
+/** @type {import('../../../node-translator/index.js').XmlNodeName} */
+const XML_NODE_NAME = 'w:tab';
+
+/** @type {import('../../../node-translator/index.js').SuperDocNodeOrKeyName} */
+const SD_NODE_NAME = 'tab';
+
+/**
+ * Encode a <w:tab> element into a SuperDoc tab node.
+ * @param {import('../../../node-translator/index.js').SCEncoderConfig} _
+ * @param {import('../../../node-translator/index.js').EncodedAttributes} [encodedAttrs]
+ * @returns {import('../../../node-translator/index.js').SCEncoderResult}
+ */
+const encode = (_, encodedAttrs) => {
+  const translated = { type: 'tab' };
+  if (encodedAttrs && Object.keys(encodedAttrs).length) {
+    translated.attrs = { ...encodedAttrs };
+  }
+  return translated;
+};
+
+/**
+ * Decode a SuperDoc tab node back into OOXML <w:tab>.
+ * @param {import('../../../node-translator/index.js').SCDecoderConfig} params
+ * @param {import('../../../node-translator/index.js').DecodedAttributes} [decodedAttrs]
+ * @returns {import('../../../node-translator/index.js').SCDecoderResult}
+ */
+const decode = (params, decodedAttrs) => {
+  const { node } = params;
+  if (!node) return;
+
+  const wTab = { name: 'w:tab' };
+  if (decodedAttrs && Object.keys(decodedAttrs).length) {
+    wTab.attributes = { ...decodedAttrs };
+  }
+
+  return {
+    name: 'w:r',
+    elements: [wTab],
+  };
+};
+
+/** @type {import('../../../node-translator/index.js').NodeTranslatorConfig} */
+export const config = {
+  xmlName: XML_NODE_NAME,
+  sdNodeOrKeyName: SD_NODE_NAME,
+  type: NodeTranslator.translatorTypes.NODE,
+  encode,
+  decode,
+  attributes: [],
+};
+
+/**
+ * The NodeTranslator instance for the w:tab element.
+ * @type {import('../../../node-translator/index.js').NodeTranslator}
+ */
+export const translator = NodeTranslator.from(config);

--- a/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/tab-translator.test.js
+++ b/packages/super-editor/src/core/super-converter/v3/handlers/w/tab/tab-translator.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { config } from './index.js';
+
+describe('w:tab translator config', () => {
+  describe('encode', () => {
+    it('encodes to a SuperDoc tab node by default', () => {
+      const res = config.encode({}, undefined);
+      expect(res).toEqual({ type: 'tab' });
+    });
+
+    it('includes all provided encoded attributes on the SuperDoc node', () => {
+      const encodedAttrs = { custom: 'x' };
+      const res = config.encode({}, encodedAttrs);
+      expect(res.type).toBe('tab');
+      expect(res.attrs).toEqual(encodedAttrs);
+    });
+  });
+
+  describe('decode', () => {
+    it('wraps <w:tab> in a <w:r> run (Google Docs compatibility)', () => {
+      const res = config.decode({ node: { type: 'tab' } }, undefined);
+      expect(res).toBeTruthy();
+      expect(res.name).toBe('w:r');
+      expect(Array.isArray(res.elements)).toBe(true);
+      expect(res.elements[0]).toEqual({ name: 'w:tab' });
+    });
+
+    it('copies decoded attributes onto <w:tab>', () => {
+      const decodedAttrs = { 'w:custom': 'foo' };
+      const res = config.decode({ node: { type: 'tab' } }, decodedAttrs);
+      expect(res.name).toBe('w:r');
+      expect(res.elements[0]).toEqual({
+        name: 'w:tab',
+        attributes: { 'w:custom': 'foo' },
+      });
+    });
+
+    it('returns undefined when params.node is missing', () => {
+      const res = config.decode({}, { 'w:foo': 'bar' });
+      expect(res).toBeUndefined();
+    });
+
+    it('does not require specific SuperDoc node type for decoding (guard only)', () => {
+      const res = config.decode({ node: { type: 'text' } }, { 'w:foo': 'bar' });
+      expect(res.name).toBe('w:r');
+      expect(res.elements[0]).toEqual({
+        name: 'w:tab',
+        attributes: { 'w:foo': 'bar' },
+      });
+    });
+  });
+
+  describe('attributes mapping metadata', () => {
+    it('exposes no attribute handlers', () => {
+      expect(Array.isArray(config.attributes)).toBe(true);
+      expect(config.attributes.length).toBe(0);
+    });
+  });
+});

--- a/packages/super-editor/src/index.js
+++ b/packages/super-editor/src/index.js
@@ -7,6 +7,7 @@ import { SuperToolbar } from './components/toolbar/super-toolbar.js';
 import { DocxZipper, helpers } from './core/index.js';
 import { Editor } from './core/Editor.js';
 import { createZip } from './core/super-converter/zipper.js';
+import { registeredHandlers } from './core/super-converter/v3/handlers/index.js';
 import { getAllowedImageDimensions } from './extensions/image/imageHelpers/processUploadedImage.js';
 import { Node, Attribute } from '@core/index.js';
 import { Extension } from '@core/Extension.js';
@@ -70,6 +71,7 @@ export {
   getRichTextExtensions,
   createZip,
   getAllowedImageDimensions,
+  registeredHandlers,
 
   // External extensions classes
   Extensions,

--- a/packages/superdoc/src/index.js
+++ b/packages/superdoc/src/index.js
@@ -4,6 +4,7 @@ import {
   getRichTextExtensions,
   createZip,
   Extensions,
+  registeredHandlers,
 } from '@harbour-enterprises/super-editor';
 import {
   helpers as superEditorHelpers,
@@ -38,6 +39,7 @@ export {
   // Super Editor
   SuperConverter,
   createZip,
+  registeredHandlers,
 
   // Custom extensions
   Extensions,


### PR DESCRIPTION
## Summary
- support w:tab in v3 converter with encode/decode
- register new tab translator
- cover tab translator with tests

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68bdda5b270883308dde0e071aa6d34f