### PR TITLE
refactor: adopt v3 table node handler

### DIFF
--- a/packages/super-editor/src/core/super-converter/v2/importer/tableImporter.js
+++ b/packages/super-editor/src/core/super-converter/v2/importer/tableImporter.js
@@ -3,19 +3,14 @@ import { eigthPointsToPixels, halfPointToPoints, twipsToPixels } from '../../hel
 /**
  * @type {import("docxImporter").NodeHandler}
  */
-export const handleAllTableNodes = (params) => {
+export const handleTableNode = (params) => {
   const { nodes } = params;
-  if (nodes.length === 0) {
+  if (nodes.length === 0 || nodes[0].name !== 'w:tbl') {
     return { nodes: [], consumed: 0 };
   }
   const node = nodes[0];
 
-  switch (node.name) {
-    case 'w:tbl':
-      return { nodes: [handleTableNode(node, params)], consumed: 1 };
-  }
-
-  return { nodes: [], consumed: 0 };
+  return { nodes: [processTableNode(node, params)], consumed: 1 };
 };
 
 /**
@@ -23,7 +18,7 @@ export const handleAllTableNodes = (params) => {
  */
 export const tableNodeHandlerEntity = {
   handlerName: 'tableNodeHandler',
-  handler: handleAllTableNodes,
+  handler: handleTableNode,
 };
 
 /**
@@ -34,7 +29,7 @@ export const tableNodeHandlerEntity = {
  * @param {boolean} insideTrackChange
  * @returns {{type: string, content: *, attrs: {borders: *, tableWidth: *, tableWidthType: *}}}
  */
-export function handleTableNode(node, params) {
+function processTableNode(node, params) {
   const { docx, nodeListHandler } = params;
   // Table styles
   const tblPr = node.elements.find((el) => el.name === 'w:tblPr');

--- a/packages/super-editor/src/tests/import/tableImporter.test.js
+++ b/packages/super-editor/src/tests/import/tableImporter.test.js
@@ -2,7 +2,7 @@ import { parseXmlToJson } from '@converter/v2/docxHelper.js';
 import { handleTrackChangeNode } from '@converter/v2/importer/trackChangesImporter.js';
 import { defaultNodeListHandler } from '@converter/v2/importer/docxImporter.js';
 import { TrackInsertMarkName } from '@extensions/track-changes/constants.js';
-import { handleAllTableNodes } from '@converter/v2/importer/tableImporter.js';
+import { handleTableNode } from '@converter/v2/importer/tableImporter.js';
 import { getTestDataByFileName } from '@tests/helpers/helpers.js';
 
 describe('table live xml test', () => {
@@ -426,7 +426,7 @@ describe('table live xml test', () => {
       'word/styles.xml': styles,
     };
 
-    const result = handleAllTableNodes({ nodes, docx, nodeListHandler: defaultNodeListHandler() });
+    const result = handleTableNode({ nodes, docx, nodeListHandler: defaultNodeListHandler() });
     expect(result.nodes.length).toBe(1);
 
     expect(result.nodes[0].type).toBe('table');
@@ -475,7 +475,7 @@ describe('table live xml test', () => {
     const docx = {
       'word/styles.xml': styles,
     };
-    const result = handleAllTableNodes({ nodes, docx, nodeListHandler: defaultNodeListHandler() });
+    const result = handleTableNode({ nodes, docx, nodeListHandler: defaultNodeListHandler() });
     expect(result.nodes[0].content[0].content[0].attrs.borders).toBeDefined();
     expect(result.nodes[0].content[0].content[1].attrs.borders).toBeDefined();
     expect(result.nodes[0].content[0].content[0].attrs.borders.right.val).toBe('none');
@@ -489,7 +489,7 @@ describe('table live xml test', () => {
     const nodes = parseXmlToJson(tableCellsNoInlineWidth).elements;
     const styles = parseXmlToJson(simpleTableStyleXml);
     const docx = { 'word/styles.xml': styles };
-    const result = handleAllTableNodes({ nodes, docx, nodeListHandler: defaultNodeListHandler() });
+    const result = handleTableNode({ nodes, docx, nodeListHandler: defaultNodeListHandler() });
 
     expect(result.nodes[0].content[0].content[0].attrs.colwidth).toEqual([390, 26]);
     expect(result.nodes[0].content[0].content[1].attrs.colwidth).toEqual([256]);
@@ -509,7 +509,7 @@ describe('table tests to check colwidth', () => {
     const body = doc.elements[0];
     const content = body.elements;
 
-    const result = handleAllTableNodes({ nodes: [content[0]], docx, nodeListHandler: defaultNodeListHandler() });
+    const result = handleTableNode({ nodes: [content[0]], docx, nodeListHandler: defaultNodeListHandler() });
     const node = result.nodes[0];
 
     expect(node.type).toBe('table');


### PR DESCRIPTION
## Summary
- refactor table importer to expose v3-style `handleTableNode`
- update table importer tests to use new handler name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be0ffdfb5c8330b1bafeb87d2f9051